### PR TITLE
delete member toc directives

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -239,11 +239,6 @@ def check_doc(app, doctree, docname):
             if 'api-class' in classes:
                 check_class(object_file, section)
 
-class MemberTocDirective(Directive):
-
-    def run(self):
-        return [nodes.rubric(text='Member and nonmember functions')]
-
 class TParamsDirective(Directive):
 
     def run(self):
@@ -288,7 +283,6 @@ def setup(app):
     # add_custom_css = getattr(app,'add_css_file',getattr(app,'add_stylesheet'))
     # add_custom_css('custom.css')
     app.connect('doctree-resolved', check_doc)
-    app.add_directive('member-toc', MemberTocDirective)
     if False:
         app.add_directive('tparams', TParamsDirective)
         app.add_directive('params', ParamsDirective)

--- a/source/iface/address-space.rst
+++ b/source/iface/address-space.rst
@@ -62,8 +62,6 @@ address_space
    
 .. seealso:: |SYCL_SPEC_MULTI_PTR|
 
-.. member-toc::
-
 (constructors)
 ==============
 	    

--- a/source/iface/buffer-accessor.rst
+++ b/source/iface/buffer-accessor.rst
@@ -39,8 +39,6 @@ const_reference  Type of const reference to buffer element
 
 .. seealso:: |SYCL_SPEC_BUFFER_ACCESSOR|
 
-.. member-toc::
-
 (constructors)
 ==============
 

--- a/source/iface/buffer.rst
+++ b/source/iface/buffer.rst
@@ -72,9 +72,6 @@ allocator_type    type of allocator for buffer data
 
 .. seealso:: |SYCL_SPEC_BUFFER|
 
-.. member-toc::
-
-
 .. _buffer-constructors:
 
 (constructors)
@@ -324,8 +321,6 @@ sycl::propery::buffer:use_host_ptr
 Use the provided host pointer and do not allocate new data on the
 host.
 
-.. member-toc::
-
 .. _use_host_ptr-constructors:
 
 (constructors)
@@ -347,8 +342,6 @@ sycl::property::use_mutex
 
 Adds the requirement that the memory owned by the SYCL buffer can be
 shared with the application via a std::mutex provided to the property.
-
-.. member-toc::
 
 .. _use_mutex-constructors:
 
@@ -379,8 +372,6 @@ sycl::property::buffer::context_bound
 
 The buffer can only be associated with a single SYCL context provided
 to the property.
-
-.. member-toc::
 
 .. _context_bound-constructors:
 

--- a/source/iface/command-group-handler.rst
+++ b/source/iface/command-group-handler.rst
@@ -28,9 +28,6 @@ function is an argument to :ref:`queue-submit`.
 
 .. seealso:: |SYCL_SPEC_HANDLER|
 
-.. member-toc::
-
-
 require
 =======
 

--- a/source/iface/command-group.rst
+++ b/source/iface/command-group.rst
@@ -26,8 +26,6 @@ sycl::command_group
 
    class command_group;
 
-.. member-toc::
-
 (constructors)
 ==============
 

--- a/source/iface/context.rst
+++ b/source/iface/context.rst
@@ -27,8 +27,6 @@ context, but a device can only be part of a single context.
 
 .. seealso:: |SYCL_SPEC_CONTEXT|
 
-.. member-toc::
-
 (constructors)
 ==============
 

--- a/source/iface/device-event.rst
+++ b/source/iface/device-event.rst
@@ -14,8 +14,6 @@ sycl::device_event
 
 .. seealso:: |SYCL_SPEC_DEVICE_EVENT|
 
-.. member-toc::
-
 wait
 ====
 

--- a/source/iface/device-selector.rst
+++ b/source/iface/device-selector.rst
@@ -35,9 +35,6 @@ operator.
 
 .. todo:: Example Custom device selector	    
 
-.. member-toc::
-
-
 (constructors)
 ==============
 

--- a/source/iface/device.rst
+++ b/source/iface/device.rst
@@ -24,9 +24,6 @@ execute kernel functions.
 
 .. seealso:: |SYCL_SPEC_DEVICE|
 
-.. member-toc::
-
-   
 (constructors)
 ==============
 

--- a/source/iface/event.rst
+++ b/source/iface/event.rst
@@ -27,8 +27,6 @@ kernel.
 
 .. seealso:: |SYCL_SPEC_EVENT|
 
-.. member-toc::
-
 (constructors)
 ==============
 

--- a/source/iface/exception.rst
+++ b/source/iface/exception.rst
@@ -20,8 +20,6 @@ sycl::exception
 
 .. seealso:: |SYCL_SPEC_EXCEPTION|
 
-.. member-toc::
-
 Container for an exception that occurs during execution. Synchronous
 API's throw exceptions that may be caught with C++ exception handling
 methods. The SYCL runtime holds exceptions that occur during
@@ -94,8 +92,6 @@ size_type
 iterator
 const_iterator
 ===============  ===
-
-.. member-toc::
 
 size
 ====

--- a/source/iface/group.rst
+++ b/source/iface/group.rst
@@ -23,8 +23,6 @@ dimensions
 
 .. seealso:: |SYCL_SPEC_GROUP|
 
-.. member-toc::
-
 get_id
 ======
 

--- a/source/iface/h_item.rst
+++ b/source/iface/h_item.rst
@@ -17,9 +17,6 @@ sycl::h_item
 
 .. seealso:: |SYCL_SPEC_H_ITEM|
 
-.. member-toc::
-
-   
 get_global
 ==========
 

--- a/source/iface/id.rst
+++ b/source/iface/id.rst
@@ -22,9 +22,6 @@ a :ref:`range`. Examples includes use as an index in an
 
 .. seealso:: |SYCL_SPEC_ID|
 
-.. member-toc::
-
-
 (constructors)
 ==============
 

--- a/source/iface/image-accessor.rst
+++ b/source/iface/image-accessor.rst
@@ -37,9 +37,6 @@ const_reference
 
 .. seealso:: |SYCL_SPEC_IMAGE_ACCESSOR|
 
-.. member-toc::
-
-
 (constructors)
 ==============
 

--- a/source/iface/image.rst
+++ b/source/iface/image.rst
@@ -29,8 +29,6 @@ AllocatorT
 
 .. seealso:: |SYCL_SPEC_IMAGE|
 
-.. member-toc::
-
 .. _image-image:
 
 (constructors)
@@ -218,8 +216,6 @@ sycl::property::image::use_host_ptr
 
 Description
 
-.. member-toc::
-
 .. _image-use_host_ptr-use_host_ptr:
 
 (constructors)
@@ -242,8 +238,6 @@ sycl::property::image::use_mutex
 
 Description
 
-.. member-toc::
-   
 .. _image-get_mutex_ptr-get_mutex_ptr:
    
 (constructors)
@@ -280,8 +274,6 @@ sycl::property::image::context_bound
    property::image
 
 Description
-
-.. member-toc::
 
 .. _image-context_bound-context_bound:
 

--- a/source/iface/item.rst
+++ b/source/iface/item.rst
@@ -33,8 +33,6 @@ with_offset     True if item has offset
 
 .. seealso:: |SYCL_SPEC_ITEM|
 
-.. member-toc::
-
 get_id
 ======
 

--- a/source/iface/kernel.rst
+++ b/source/iface/kernel.rst
@@ -24,9 +24,6 @@ Abstraction of a kernel object.
 
 .. seealso:: |SYCL_SPEC_KERNEL|
 
-.. member-toc::
-
-
 (constructors)
 ==============
 

--- a/source/iface/local-accessor.rst
+++ b/source/iface/local-accessor.rst
@@ -37,8 +37,6 @@ const_reference
 
 .. seealso:: |SYCL_SPEC_LOCAL_ACCESSOR|
 
-.. member-toc::
-
 (constructors)
 ==============
 

--- a/source/iface/nd_item.rst
+++ b/source/iface/nd_item.rst
@@ -25,8 +25,6 @@ contains the :ref:`nd_range` defining the index space.
 
 .. seealso:: |SYCL_SPEC_ND_ITEM|
 
-.. member-toc::
-
 get_global_id
 =============
 

--- a/source/iface/nd_range.rst
+++ b/source/iface/nd_range.rst
@@ -31,8 +31,6 @@ dimensions        Number of dimensions
 
 .. seealso:: |SYCL_SPEC_ND_RANGE|
 
-.. member-toc::
-   
 (constructors)
 ==============
 

--- a/source/iface/platform.rst
+++ b/source/iface/platform.rst
@@ -24,8 +24,6 @@ A platform contains 1 or more SYCL devices, or a host device.
 
 .. seealso:: |SYCL_SPEC_PLATFORM|
    
-.. member-toc::
-
 .. _platform-example:
 
 .. rubric:: Example

--- a/source/iface/private_memory.rst
+++ b/source/iface/private_memory.rst
@@ -13,8 +13,6 @@ sycl::private_memory
    
 .. seealso:: |SYCL_SPEC_PRIVATE_MEMORY|
 
-.. member-toc::
-
 (constructors)
 ==============
 

--- a/source/iface/properties.rst
+++ b/source/iface/properties.rst
@@ -12,9 +12,6 @@
 
    class property_list;
 
-.. member-toc::
-
-
 property_list
 =============
 

--- a/source/iface/queue.rst
+++ b/source/iface/queue.rst
@@ -37,8 +37,6 @@ to monitor the completion of the task for completion and errors.
 
 .. seealso:: |SYCL_SPEC_QUEUE|
 
-.. member-toc::
-
 (constructors)
 ==============
 

--- a/source/iface/range.rst
+++ b/source/iface/range.rst
@@ -29,9 +29,6 @@ dimensions        Number of dimensions
 
 .. seealso:: |SYCL_SPEC_RANGE|
 
-.. member-toc::
-
-
 (constructors)
 ==============
 

--- a/source/iface/usm_allocator.rst
+++ b/source/iface/usm_allocator.rst
@@ -45,8 +45,6 @@ value_type
 
 .. seealso:: |SYCL_SPEC_USM_ALLOCATOR|
 
-.. member-toc::
-
 (constructors)
 ==============
 


### PR DESCRIPTION
I intended to automatically generate a specialized TOC, but the sphinx book theme puts navigation in the right hand column that serves the same purpose.