### PR TITLE
get sphinx-book-theme from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@
 pre-commit
 reuse
 Sphinx
-sphinx-book-theme
+git+https://github.com/executablebooks/sphinx-book-theme.git
 sphinxcontrib-spelling


### PR DESCRIPTION
Fixes an issue with misaligned line numbers and code in examples