### PR TITLE
Add device get_info reference to specification for further details on struct types

### DIFF
--- a/source/iface/device.rst
+++ b/source/iface/device.rst
@@ -284,6 +284,7 @@ Device Info
 Used as a template parameter for get_info_ to determine the type of
 information.
 
+See `SYCL Specification <https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_device_information_descriptors>`__ for further details on these structs.
 
 .. _info-device_type:
 

--- a/source/iface/device.rst
+++ b/source/iface/device.rst
@@ -284,7 +284,7 @@ Device Info
 Used as a template parameter for get_info_ to determine the type of
 information.
 
-See `SYCL Specification <https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_device_information_descriptors>`__ for further details on these structs.
+See `SYCL Specification <https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_device_information_descriptors>`__ for further details on these types.
 
 .. _info-device_type:
 


### PR DESCRIPTION
Small change but fairly needed to be able to tell what each struct contains