### PR TITLE
Updated example SYCL includes to 2020 version

### DIFF
--- a/source/examples/get-platforms.cpp
+++ b/source/examples/get-platforms.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main() {
   auto platforms = sycl::platform::get_platforms();

--- a/source/examples/gpu-platform.cpp
+++ b/source/examples/gpu-platform.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main() {
   // Select a platform with a GPU

--- a/source/examples/host-task.cpp
+++ b/source/examples/host-task.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main() {
   const int n = 10;

--- a/source/examples/std-vector.cpp
+++ b/source/examples/std-vector.cpp
@@ -4,17 +4,15 @@
 
 #include <vector>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
-using namespace sycl;
-
-const int size = 10;
+constexpr int size = 10;
 
 int main() {
   queue q;
 
   // USM allocator for data of type int in shared memory
-  typedef usm_allocator<int, usm::alloc::shared> vec_alloc;
+  typedef usm_allocator<int, sycl::usm::alloc::shared> vec_alloc;
   // Create allocator for device associated with q
   vec_alloc myAlloc(q);
   // Create std vectors with the allocator
@@ -32,9 +30,9 @@ int main() {
     c[i] = i;
   }
 
-  q.submit([&](handler &h) {
-     h.parallel_for(range<1>(size),
-                    [=](id<1> idx) { C[idx] = A[idx] + B[idx]; });
+  q.submit([&](sycl::handler &h) {
+     h.parallel_for(sycl::range<1>(size),
+                    [=](sycl::id<1> idx) { C[idx] = A[idx] + B[idx]; });
    }).wait();
 
   for (int i = 0; i < size; i++)

--- a/source/examples/stream.cpp
+++ b/source/examples/stream.cpp
@@ -2,15 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q;
+
   q.submit([&](sycl::handler &h) {
     // setup sycl stream class to print standard output from
     // device code
     auto out = sycl::stream(1024, 768, h);
     auto task = [=]() { out << "In a task\n"; };
-    h.single_task(task);
+    h.single_task<class stream_task>(task);
   });
+  q.wait();
 }


### PR DESCRIPTION
Additionally made std-vector example not have ```using namespace sycl``` as the others don't and it reduces clarity for newer people who don't know all the SYCL functions well yet.