### PR TITLE
Improved format consistency of examples

### DIFF
--- a/source/examples/gpu-selector.cpp
+++ b/source/examples/gpu-selector.cpp
@@ -2,19 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <CL/sycl.hpp>
-
-using namespace sycl;
+#include <sycl/sycl.hpp>
 
 int main() {
-  device d;
+  sycl::device d;
 
   try {
-    d = device(gpu_selector());
-  } catch (exception const &e) {
+    d = sycl::device(sycl::gpu_selector());
+  } catch (sycl::exception const &e) {
     std::cout << "Cannot select a GPU\n" << e.what() << "\n";
     std::cout << "Using a CPU device\n";
-    d = device(cpu_selector());
+    d = sycl::device(sycl::cpu_selector());
   }
 
   std::cout << "Using " << d.get_info<sycl::info::device::name>();

--- a/source/examples/stream.out
+++ b/source/examples/stream.out
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2020 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
+In a task

--- a/source/iface/buffer.rst
+++ b/source/iface/buffer.rst
@@ -8,6 +8,7 @@
  Buffers
 *********
 
+.. _buffer:
 
 .. rst-class:: api-class
 
@@ -72,6 +73,10 @@ Memory allocation
    `Data Parallel C++ Guide <https://link.springer.com/content/pdf/10.1007%2F978-1-4842-5574-2.pdf#page=96>`__
 
    `SYCL Specification <https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:buffers>`__
+
+.. rubric:: Example
+
+See :ref:`queue-example-2 <queue-example-2>` for example of buffer usage.
 
 .. _buffer-constructors:
 
@@ -225,7 +230,6 @@ Returns a accessor to the buffer.
 ``accessOffset``         Origin of the sub-buffer that is accessed
 =======================  ==========
 
-
 ``set_final_data``
 ==================
 
@@ -273,7 +277,6 @@ Set the write back.
   bool is_sub_buffer() const;
 
 Returns True if this is a sub-buffer.
-
 
 ``reinterpret``
 ===============

--- a/source/iface/buffer.rst
+++ b/source/iface/buffer.rst
@@ -8,7 +8,6 @@
  Buffers
 *********
 
-.. _buffer:
 
 .. rst-class:: api-class
 
@@ -73,10 +72,6 @@ Memory allocation
    `Data Parallel C++ Guide <https://link.springer.com/content/pdf/10.1007%2F978-1-4842-5574-2.pdf#page=96>`__
 
    `SYCL Specification <https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:buffers>`__
-
-.. rubric:: Example
-
-See :ref:`queue-example-2 <queue-example-2>` for example of buffer usage.
 
 .. _buffer-constructors:
 
@@ -230,6 +225,7 @@ Returns a accessor to the buffer.
 ``accessOffset``         Origin of the sub-buffer that is accessed
 =======================  ==========
 
+
 ``set_final_data``
 ==================
 
@@ -277,6 +273,7 @@ Set the write back.
   bool is_sub_buffer() const;
 
 Returns True if this is a sub-buffer.
+
 
 ``reinterpret``
 ===============

--- a/source/iface/device-selector.rst
+++ b/source/iface/device-selector.rst
@@ -116,7 +116,11 @@ Create a device selector by copying another one.
 
 .. seealso:: |SYCL_SPEC_DEVICE_SELECTORS|
 
- .. rubric:: Example
+.. _device-selector-example:
+
+=========
+Example 1
+=========
 
 .. literalinclude:: /examples/gpu-selector.cpp
    :lines: 5-

--- a/source/iface/device.rst
+++ b/source/iface/device.rst
@@ -185,11 +185,7 @@ Returns vector of devices filtered by :ref:`info-device_type`.
 
 .. rubric:: Example
 
-Enumerate the GPU devices.
-
-.. literalinclude:: /examples/get_devices.cpp
-   :lines: 5-
-   :linenos:
+See get_devices-example_.
 
 ===========
 Device Info
@@ -391,3 +387,15 @@ See get_info_.
   };
 
 See get_info_.
+
+.. _get_devices-example:
+
+=========
+Example 1
+=========
+
+Enumerate the GPU devices.
+
+.. literalinclude:: /examples/get_devices.cpp
+   :lines: 5-
+   :linenos:

--- a/source/iface/device.rst
+++ b/source/iface/device.rst
@@ -104,7 +104,7 @@ Returns information about the device as determined by ``param``. See
 
 .. rubric:: Example
 
-See :ref:`platform-example`.
+See :ref:`platform-example <platform-example>`.
 
 ``get_backend_info``
 ====================

--- a/source/iface/device.rst
+++ b/source/iface/device.rst
@@ -152,16 +152,16 @@ property.
 .. rubric:: Template parameters
 
 =================  ===
-``prop``           See `sycl::info::partition_property`_
+``prop``           See `sycl::info::partition_property`_.
 =================  ===
 
 
 .. rubric:: Parameters
 
 ==================  ===
-``count``           Number of compute units per sub-device
-``counts``          Vector with number of compute units for each sub-device
-``affinityDomain``  See `sycl::info::partition_affinity_domain`_
+``count``           Number of compute units per sub-device.
+``counts``          Vector with number of compute units for each sub-device.
+``affinityDomain``  See `sycl::info::partition_affinity_domain`_.
 ==================  ===
 
 .. rubric:: Exceptions
@@ -185,7 +185,7 @@ Returns vector of devices filtered by :ref:`info-device_type`.
 
 .. rubric:: Example
 
-Enumerate the GPU devices
+Enumerate the GPU devices.
 
 .. literalinclude:: /examples/get_devices.cpp
    :lines: 5-
@@ -317,7 +317,7 @@ See platform :ref:`platform-get_devices` and device :ref:`device-get_devices`.
     partition_by_affinity_domain
   };
 
-See create_sub_devices_
+See create_sub_devices_.
 
 ``sycl::info::partition_affinity_domain``
 =========================================
@@ -334,7 +334,7 @@ See create_sub_devices_
     next_partitionable
   };
 
-See create_sub_devices_
+See create_sub_devices_.
 
 .. _local_mem_type:
 
@@ -345,7 +345,7 @@ See create_sub_devices_
 
   enum class local_mem_type : int { none, local, global };
 
-See get_info_
+See get_info_.
 
 .. _fp_config:
 
@@ -365,7 +365,7 @@ See get_info_
     soft_float
   };
 
-See get_info_
+See get_info_.
 
 .. _cache_type:
 
@@ -376,7 +376,7 @@ See get_info_
 
   enum class global_mem_cache_type : int { none, read_only, read_write };
 
-See get_info_
+See get_info_.
 
 .. _exec_capability:
 
@@ -390,4 +390,4 @@ See get_info_
     exec_native_kernel
   };
 
-See get_info_
+See get_info_.

--- a/source/iface/exception.rst
+++ b/source/iface/exception.rst
@@ -261,7 +261,7 @@ Optional feature or extension is not available on the :ref:`device`.
 .. rubric:: Parameters
 
 =============  ===
-``e``          List of asynchronous exceptions. See `sycl::exception_list`_
+``e``          List of asynchronous exceptions. See `sycl::exception_list`_.
 =============  ===
 
 The SYCL runtime delivers asynchronous exceptions by invoking an

--- a/source/iface/platform.rst
+++ b/source/iface/platform.rst
@@ -166,9 +166,9 @@ the type of information.
 
 .. _platform-example:
 
-=======
-Example
-=======
+=========
+Example 1
+=========
 
 Enumerate the platforms and the devices they contain.
 

--- a/source/iface/stream.rst
+++ b/source/iface/stream.rst
@@ -6,19 +6,10 @@
 Streams
 *******
 
-
 Kernels may not use std streams for input/output. ``sycl::stream``
 provides similar functionality.
 
-.. _stream-example:
-
-.. rubric:: Example
-
-Output to console in a kernel.
-
-.. literalinclude:: /examples/stream.cpp
-   :linenos:
-   :start-after: SPDX-License
+.. _stream:
 
 .. rst-class:: api-class
 
@@ -119,3 +110,20 @@ compatibility.  get_max_statement_size() is a deprecated query.
    const sycl::stream_manipulator defaultfloat = sycl::stream_manipulator::defaultfloat;
    __precision_manipulator__ setprecision(int precision);
    __width_manipulator__ setw(int width);
+
+.. _stream-example:
+
+=========
+Example 1
+=========
+
+Output text to the console in a kernel.
+
+.. literalinclude:: /examples/stream.cpp
+   :linenos:
+   :start-after: SPDX-License
+
+Output:
+
+.. literalinclude:: /examples/stream.out
+   :lines: 5-


### PR DESCRIPTION
Made it so whenever there is an example directly under a function, it always uses the example rubric which then links to an example on a different page or on the bottom of the same page.
Full examples are now located intuitively at the bottom of the page (similar to cppreference) and have numbered headers which makes it easier to label references to them if there are multiple per page.