### PR TITLE
dpcpp build

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,7 +47,7 @@ jobs:
         cd source/examples
         mkdir build
         cd build
-        cmake ..
+        CXX=dpcpp cmake ..
         make -j
         ctest --label-exclude gpu
         

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,4 +50,3 @@ jobs:
         CXX=dpcpp cmake ..
         make -j
         ctest --label-exclude gpu
-        

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,3 +22,32 @@ jobs:
         pre-commit run --all
         # Need to install dpcpp without blowing up time
         # python doc.py examples
+
+  dpcpp:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache install
+      id: cache-dpcpp
+      uses: actions/cache@v2
+      with:
+        path: /opt/intel/oneapi
+        key: oneapi-update3
+    - name: Install
+      if: steps.cache-dpcpp.outputs.cache-hit != 'true'
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
+        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+    - name: Build Examples
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cd source/examples
+        mkdir build
+        cd build
+        cmake ..
+        make -j
+        ctest --label-exclude gpu
+        

--- a/source/examples/CMakeLists.txt
+++ b/source/examples/CMakeLists.txt
@@ -6,7 +6,6 @@ cmake_minimum_required(VERSION 3.13)
 project(SYCL_Reference)
 
 enable_testing()
-set(CMAKE_CXX_COMPILER dpcpp)
 
 add_compile_options(-Wall -Wextra -Werror)
 

--- a/source/examples/CMakeLists.txt
+++ b/source/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ project(SYCL_Reference)
 enable_testing()
 set(CMAKE_CXX_COMPILER dpcpp)
 
-add_compile_options(-Wall -Wextra -pedantic -Werror)
+add_compile_options(-Wall -Wextra -Werror)
 
 
 function(add_example name)
@@ -25,3 +25,4 @@ add_example(get-platforms)
 add_example(get_devices)
 add_example(stream)
 add_example(gpu-selector)
+set_tests_properties(gpu-platform PROPERTIES LABELS gpu)

--- a/source/examples/event-elapsed-time.cpp
+++ b/source/examples/event-elapsed-time.cpp
@@ -6,7 +6,7 @@
 
 int main() {
   sycl::property_list properties{sycl::property::queue::enable_profiling()};
-  auto q = sycl::queue(sycl::gpu_selector(), properties);
+  auto q = sycl::queue(sycl::default_selector(), properties);
 
   std::cout
       << "  Platform: "


### PR DESCRIPTION
Verify that the examples build and run with dpcpp
-pedantic causes a warning in exception test. It seems like a bug in dpcpp so disabling for now.

@martinstarkov: would it be possible to add a computecpp build step in checks.yml? That is the safest way to prevent me from creating examples that don't work.