### PR TITLE
[KHRGA-139] Fixed USM contents

### DIFF
--- a/source/iface/command-group-handler.rst
+++ b/source/iface/command-group-handler.rst
@@ -452,7 +452,7 @@ case the SYCL runtime will construct an instance of
 .. seealso:: :ref:`parallel_for_hierarchical`
 
 
-.. _hanlder_expl_mem_ops:
+.. _handler_expl_mem_ops:
 
 Functions for explicit memory operations
 ========================================

--- a/source/iface/command-group-handler.rst
+++ b/source/iface/command-group-handler.rst
@@ -452,6 +452,8 @@ case the SYCL runtime will construct an instance of
 .. seealso:: :ref:`parallel_for_hierarchical`
 
 
+.. _hanlder_expl_mem_ops:
+
 Functions for explicit memory operations
 ========================================
 

--- a/source/iface/queue.rst
+++ b/source/iface/queue.rst
@@ -355,7 +355,7 @@ See `queue-example-2`_.
   event memcpy(void* dest, const void* src, size_t numBytes,
              const std::vector<event>& depEvents);
 
-Set memory allocated with :ref:`malloc_device`.
+Set memory allocated with :ref:`usm_allocations`.
 
 .. rubric:: Example
 
@@ -389,7 +389,7 @@ See :ref:`event-elapsed-time-example<event-elapsed-time>`.
   event memset(void* ptr, int value, size_t numBytes,
              const std::vector<event>& depEvents);
 
-Set memory allocated with :ref:`malloc_device`. For usage, see
+Set memory allocated with :ref:`usm_allocations`. For usage, see
 :ref:`event-elapsed-time`.
 
 .. _queue-fill:
@@ -408,7 +408,7 @@ Set memory allocated with :ref:`malloc_device`. For usage, see
   event fill(void* ptr, const T& pattern, size_t count,
            const std::vector<event>& depEvents);
 
-Set memory allocated with :ref:`malloc_device`.
+Set memory allocated with :ref:`usm_allocations`.
 
 ``prefetch``
 ============

--- a/source/iface/usm_allocations.rst
+++ b/source/iface/usm_allocations.rst
@@ -100,7 +100,6 @@ provides the :ref:`device` and :ref:`context`.
 Allocation functions
 ====================
 
-=======================
 ``sycl::malloc_device``
 =======================
 
@@ -172,7 +171,6 @@ passed to ``sycl::free`` to avoid a memory leak.
 See :ref:`Events exapmle 1 <event-elapsed-time>` for usage.
 
 
-=====================
 ``sycl::malloc_host``
 =====================
 
@@ -240,7 +238,6 @@ passed to ``sycl::free`` to avoid a memory leak.
 
 See :ref:`usm-implicit-data-movement` for usage.
 
-=======================
 ``sycl::malloc_shared``
 =======================
 
@@ -326,7 +323,6 @@ context must have ``sycl::aspect::usm_host_allocations``. When ``kind`` is
 the allocation function throws a synchronous ``sycl::exception`` with the
 ``sycl::errc::feature_not_supported`` error code.
 
-================
 ``sycl::malloc``
 ================
 
@@ -405,7 +401,6 @@ passed to ``sycl::free`` to avoid a memory leak.
 ``propList``        Optional property list.
 ==================  ===
 
-=============================
 Memory deallocation functions
 =============================
 

--- a/source/iface/usm_allocations.rst
+++ b/source/iface/usm_allocations.rst
@@ -2,20 +2,14 @@
   Copyright 2020 The Khronos Group Inc.
   SPDX-License-Identifier: CC-BY-4.0
 
-.. temp ref
-.. _malloc_device:
+.. _usm_allocations:
 
 ***************
 USM allocations
 ***************
 
-.. _usm_allocations:
-
-.. rst-class:: api-class
-
-
 The USM offers a range of allocation functions, each designed to
-accommodate potential future extensions by accepting a ``property_list``
+accommodate potential future extensions by accepting a ``sycl::property_list``
 parameter. It's important to note that the core SYCL specification
 currently lacks any specific definitions for USM allocation properties.
 Some of the allocation functions support explicit alignment parameters,
@@ -31,13 +25,13 @@ C++ allocator interface
 
 .. _allocator_interface:
 
-SYCL defines an allocator class named ``usm_allocator`` that satisfies
-the C++ named requirement ``Allocator``. The ``AllocKind`` template parameter
-can be either ``usm::alloc::host`` or
-``usm::alloc::shared``, causing the allocator to make
+SYCL defines an allocator class named ``sycl::usm_allocator`` that
+satisfies the C++ named requirement ``Allocator``. The ``AllocKind``
+template parameter can be either ``sycl::usm::alloc::host`` or
+``sycl::usm::alloc::shared``, causing the allocator to make
 either host USM allocations or shared USM allocations.
 
-The ``usm_allocator`` class has a template argument ``Alignment``,
+The ``sycl::usm_allocator`` class has a template argument ``Alignment``,
 which specifies the minimum alignment for memory that it allocates.
 This alignment is used even if the allocator is rebound to a different
 type. Memory allocated by this allocator is suitably aligned for objects
@@ -51,49 +45,51 @@ of its underlying ``value_type`` or at the alignment specified by
 ::
 
    template <typename T, sycl::usm::alloc AllocKind, size_t Alignment = 0>
-
    class usm_allocator;
 
 .. rubric:: Template parameters
 
 =============  ===
-``T``          Type of allocated element
-``AllocKind``  Type of allocation, see `usm-alloc`
-``Alignment``  Alignment of the allocation
+``T``          Type of allocated element.
+``AllocKind``  Type of allocation.
+``Alignment``  Alignment of the allocation.
 =============  ===
 
-There is no specialization for ``usm::alloc::device`` because an ``Allocator``
-is required to allocate memory that is accessible on the host.
+There is no specialization for ``sycl::usm::alloc::device`` because an
+``Allocator`` is required to allocate memory that is accessible on the host.
 
 (constructors)
 ==============
 
 ::
 
-  usm_allocator(const context& syclContext, const device& syclDevice,
-              const property_list& propList = {});
+  usm_allocator(const sycl::context& syclContext,
+                const sycl::device& syclDevice,
+                const sycl::property_list& propList = {});
 
-  usm_allocator(const queue& syclQueue, const property_list& propList = {});
+  usm_allocator(const sycl::queue& syclQueue,
+                const sycl::property_list& propList = {});
 
-Constructs a ``usm_allocator`` instance that allocates USM for the provided
-context and device presented with first constructor.
-The second constructor present a simplified form where ``syclQueue`` provides
-the ``device`` and ``context``.
+Constructs a ``sycl::usm_allocator`` instance that allocates USM for
+the provided context and device presented with first constructor.
+The second constructor present a simplified form where ``syclQueue``
+provides the :ref:`device` and :ref:`context`.
 
 .. rubric:: Exceptions
 
-``errc::invalid``
-  If ``syclContext`` does not encapsulate the SYCL ``device`` returned
+``sycl::errc::invalid``
+  If ``syclContext`` does not encapsulate the ``sycl::device`` returned
   by ``deviceSelector``.
 
-``errc::feature_not_supported``
-  If ``AllocKind`` is ``usm::alloc::host``, the constructors throws a synchronous
-  ``exception`` with this error code if no device in ``syclContext`` has
-  ``aspect::usm_host_allocations``. The ``syclDevice`` is ignored for this allocation kind.
+``sycl::errc::feature_not_supported``
+  If ``AllocKind`` is ``sycl::usm::alloc::host``, the constructors throws a synchronous
+  ``sycl::exception`` with this error code if no device in ``syclContext`` has
+  ``sycl::aspect::usm_host_allocations``. The ``syclDevice`` is ignored for this
+  allocation kind.
 
-  If ``AllocKind`` is ``usm::alloc::shared``, the constructors throws a synchronous
-  ``exception`` with this error code if the ``syclDevice``
-  does not have ``aspect::usm_shared_allocations``.
+  If ``AllocKind`` is ``sycl::usm::alloc::shared``, the constructors throws a synchronous
+  ``sycl::exception`` with this error code if the ``syclDevice``
+  does not have ``sycl::aspect::usm_shared_allocations``.
 
 .. seealso:: `C++ Allocator <https://en.cppreference.com/w/cpp/named_req/Allocator>`__
 
@@ -110,52 +106,55 @@ Allocation functions
 
 ::
 
-   void* sycl::malloc_device(size_t numBytes, const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+   void* sycl::malloc_device(size_t numBytes,
+                             const sycl::device& syclDevice,
+                             const sycl::context& syclContext,
+                             const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc_device(size_t count, const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+   T* sycl::malloc_device(size_t count,
+                          const sycl::device& syclDevice,
+                          const sycl::context& syclContext,
+                          const sycl::property_list& propList = {});
 
-   void* sycl::malloc_device(size_t numBytes, const queue& syclQueue,
-                          const property_list& propList = {});
+   void* sycl::malloc_device(size_t numBytes,
+                             const sycl::queue& syclQueue,
+                             const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc_device(size_t count, const queue& syclQueue,
-                          const property_list& propList = {});
+   T* sycl::malloc_device(size_t count, const sycl::queue& syclQueue,
+                          const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc_device(size_t alignment, size_t numBytes,
-                          const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+                                    const sycl::device& syclDevice,
+                                    const sycl::context& syclContext,
+                                    const sycl::property_list& propList = {});
 
    template <typename T>
    T* sycl::aligned_alloc_device(size_t alignment, size_t count,
-                          const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+                                 const sycl::device& syclDevice,
+                                 const sycl::context& syclContext,
+                                 const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc_device(size_t alignment, size_t numBytes,
-                          const queue& syclQueue,
-                          const property_list& propList = {});
+                                    const sycl::queue& syclQueue,
+                                    const sycl::property_list& propList = {});
 
    template <typename T>
    T* sycl::aligned_alloc_device(size_t alignment, size_t count,
-                          const queue& syclQueue,
-                          const property_list& propList = {})
+                                 const sycl::queue& syclQueue,
+                                 const sycl::property_list& propList = {})
 
 .. rubric:: Parameters
 
 ==================  ===
-``alignment``       alignment of allocated data
-``numBytes``        allocation size in bytes
-``count``           number of elements
-``syclDevice``      See :ref:`device`
-``syclQueue``       See :ref:`queue`
-``syclContext``     See :ref:`context`
-``propList``
+``alignment``       Alignment of allocated data.
+``numBytes``        Allocation size in bytes.
+``count``           Number of elements.
+``syclDevice``      See :ref:`device`.
+``syclQueue``       See :ref:`queue`.
+``syclContext``     See :ref:`context`.
+``propList``        Optional property list.
 ==================  ===
 
 On successful USM device allocation, these functions return a pointer to
@@ -170,7 +169,7 @@ The value returned is unspecified in this case, and the returned pointer
 may not be used to access storage. If this pointer is not null, it must be
 passed to ``sycl::free`` to avoid a memory leak.
 
-See :ref:`event-elapsed-time` for usage.
+See :ref:`Events exapmle 1 <event-elapsed-time>` for usage.
 
 
 =====================
@@ -179,48 +178,52 @@ See :ref:`event-elapsed-time` for usage.
 
 ::
 
-   void* sycl::malloc_host(size_t numBytes, const context& syclContext,
-                        const property_list& propList = {});
+   void* sycl::malloc_host(size_t numBytes,
+                           const sycl::context& syclContext,
+                           const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc_host(size_t count, const context& syclContext,
-                        const property_list& propList = {});
+   T* sycl::malloc_host(size_t count,
+                        const sycl::context& syclContext,
+                        const sycl::property_list& propList = {});
 
-   void* sycl::malloc_host(size_t numBytes, const queue& syclQueue,
-                        const property_list& propList = {});
+   void* sycl::malloc_host(size_t numBytes,
+                           const sycl::queue& syclQueue,
+                           const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc_host(size_t count, const queue& syclQueue,
-                        const property_list& propList = {});
+   T* sycl::malloc_host(size_t count,
+                        const sycl::queue& syclQueue,
+                        const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc_host(size_t alignment, size_t numBytes,
-                        const context& syclContext,
-                        const property_list& propList = {});
+                                  const sycl::context& syclContext,
+                                  const sycl::property_list& propList = {});
 
    template <typename T>
    T* sycl::aligned_alloc_host(size_t alignment, size_t count,
-                        const context& syclContext,
-                        const property_list& propList = {});
+                               const sycl::context& syclContext,
+                               const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc_host(size_t alignment, size_t numBytes,
-                        const queue& syclQueue,
-                        const property_list& propList = {});
+                                  const sycl::queue& syclQueue,
+                                  const sycl::property_list& propList = {});
 
    template <typename T>
    T* sycl::aligned_alloc_host(size_t alignment, size_t count,
-                        const queue& syclQueue,
-                        const property_list& propList = {});
+                               const sycl::queue& syclQueue,
+                               const sycl::property_list& propList = {});
 
 .. rubric:: Parameters
 
 ==================  ===
-``alignment``       alignment of allocated data
-``numBytes``        allocation size in bytes
-``count``           number of elements
-``syclDevice``      See :ref:`device`
-``syclQueue``       See :ref:`queue`
-``syclContext``     See :ref:`context`
-``propList``
+``alignment``       Alignment of allocated data.
+``numBytes``        Allocation size in bytes.
+``count``           Number of elements.
+``syclDevice``      See :ref:`device`.
+``syclQueue``       See :ref:`queue`.
+``syclContext``     See :ref:`context`.
+``propList``        Optional property list.
 ==================  ===
 
 On successful USM host allocation, these functions return a pointer
@@ -243,52 +246,56 @@ See :ref:`usm-implicit-data-movement` for usage.
 
 ::
 
-   void* sycl::malloc_shared(size_t numBytes, const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+   void* sycl::malloc_shared(size_t numBytes,
+                             const sycl::device& syclDevice,
+                             const sycl::context& syclContext,
+                             const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc_shared(size_t count, const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+   T* sycl::malloc_shared(size_t count,
+                          const sycl::device& syclDevice,
+                          const sycl::context& syclContext,
+                          const sycl::property_list& propList = {});
 
-   void* sycl::malloc_shared(size_t numBytes, const queue& syclQueue,
-                          const property_list& propList = {});
+   void* sycl::malloc_shared(size_t numBytes,
+                             const sycl::queue& syclQueue,
+                             const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc_shared(size_t count, const queue& syclQueue,
-                          const property_list& propList = {});
+   T* sycl::malloc_shared(size_t count,
+                          const sycl::queue& syclQueue,
+                          const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc_shared(size_t alignment, size_t numBytes,
-                          const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+                                    const sycl::device& syclDevice,
+                                    const sycl::context& syclContext,
+                                    const sycl::property_list& propList = {});
 
    template <typename T>
    T* sycl::aligned_alloc_shared(size_t alignment, size_t count,
-                          const device& syclDevice,
-                          const context& syclContext,
-                          const property_list& propList = {});
+                                 const sycl::device& syclDevice,
+                                 const sycl::context& syclContext,
+                                 const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc_shared(size_t alignment, size_t numBytes,
-                          const queue& syclQueue,
-                          const property_list& propList = {});
+                                    const sycl::queue& syclQueue,
+                                    const sycl::property_list& propList = {});
 
    template <typename T>
    T* sycl::aligned_alloc_shared(size_t alignment, size_t count,
-                          const queue& syclQueue,
-                          const property_list& propList = {});
+                                 const sycl::queue& syclQueue,
+                                 const sycl::property_list& propList = {});
 
 .. rubric:: Parameters
 
 ==================  ===
-``alignment``       alignment of allocated data
-``numBytes``        allocation size in bytes
-``count``           number of elements
-``syclDevice``      See :ref:`device`
-``syclQueue``       See :ref:`queue`
-``syclContext``     See :ref:`context`
-``propList``
+``alignment``       Alignment of allocated data.
+``numBytes``        Allocation size in bytes.
+``count``           Number of elements.
+``syclDevice``      See :ref:`device`.
+``syclQueue``       See :ref:`queue`.
+``syclContext``     See :ref:`context`.
+``propList``        Optional property list.
 ==================  ===
 
 On successful USM shared allocation, these functions return a pointer to the
@@ -310,14 +317,14 @@ Parameterized allocation functions
 ==================================
 
 The functions below take a ``kind`` parameter that specifies the type of
-USM to allocate. When ``kind`` is ``usm::alloc::device``, then the
-allocation device must have ``aspect::usm_device_allocations``.
-When kind is ``usm::alloc::host``, at least one device in the allocation
-context must have ``aspect::usm_host_allocations``. When ``kind`` is
-``usm::alloc::shared``, the allocation device must have
-``aspect::usm_shared_allocations``. If these requirements are violated,
-the allocation function throws a synchronous ``exception`` with the
-``errc::feature_not_supported`` error code.
+USM to allocate. When ``kind`` is ``sycl::usm::alloc::device``, then the
+allocation device must have ``sycl::aspect::usm_device_allocations``.
+When kind is ``sycl::usm::alloc::host``, at least one device in the allocation
+context must have ``sycl::aspect::usm_host_allocations``. When ``kind`` is
+``sycl::usm::alloc::shared``, the allocation device must have
+``sycl::aspect::usm_shared_allocations``. If these requirements are violated,
+the allocation function throws a synchronous ``sycl::exception`` with the
+``sycl::errc::feature_not_supported`` error code.
 
 ================
 ``sycl::malloc``
@@ -325,38 +332,53 @@ the allocation function throws a synchronous ``exception`` with the
 
 ::
 
-   void* sycl::malloc(size_t numBytes, const device& syclDevice,
-                   const context& syclContext, usm::alloc kind,
-                   const property_list& propList = {});
+   void* sycl::malloc(size_t numBytes,
+                      const sycl::device& syclDevice,
+                      const sycl::context& syclContext,
+                      sycl::usm::alloc kind,
+                      const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc(size_t count, const device& syclDevice,
-                   const context& syclContext, usm::alloc kind,
-                   const property_list& propList = {});
+   T* sycl::malloc(size_t count,
+                   const sycl::device& syclDevice,
+                   const sycl::context& syclContext,
+                   sycl::usm::alloc kind,
+                   const sycl::property_list& propList = {});
 
-   void* sycl::malloc(size_t numBytes, const queue& syclQueue, usm::alloc kind,
-                   const property_list& propList = {});
+   void* sycl::malloc(size_t numBytes,
+                      const sycl::queue& syclQueue,
+                      sycl::usm::alloc kind,
+                      const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::malloc(size_t count, const queue& syclQueue, usm::alloc kind,
-                   const property_list& propList = {});
+   T* sycl::malloc(size_t count,
+                   const sycl::queue& syclQueue,
+                   sycl::usm::alloc kind,
+                   const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc(size_t alignment, size_t numBytes,
-                    const device& syclDevice, const context& syclContext,
-                    usm::alloc kind, const property_list& propList = {});
+                             const sycl::device& syclDevice,
+                             const sycl::context& syclContext,
+                             sycl::usm::alloc kind,
+                             const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::aligned_alloc(size_t alignment, size_t count, const device& syclDevice,
-                    const context& syclContext, usm::alloc kind,
-                    const property_list& propList = {});
+   T* sycl::aligned_alloc(size_t alignment, size_t count,
+                          const sycl::device& syclDevice,
+                          const sycl::context& syclContext,
+                          sycl::usm::alloc kind,
+                          const sycl::property_list& propList = {});
 
    void* sycl::aligned_alloc(size_t alignment, size_t numBytes,
-                    const queue& syclQueue, usm::alloc kind,
-                    const property_list& propList = {});
+                             const sycl::queue& syclQueue,
+                             sycl::usm::alloc kind,
+                             const sycl::property_list& propList = {});
 
    template <typename T>
-   T* sycl::aligned_alloc(size_t alignment, size_t count, const queue& syclQueue,
-                    usm::alloc kind, const property_list& propList = {});
+   T* sycl::aligned_alloc(size_t alignment, size_t count,
+                          const sycl::queue& syclQueue,
+                          sycl::usm::alloc kind,
+                          const sycl::property_list& propList = {});
 
 
 On successful USM shared allocation, these functions return a pointer to the
@@ -373,14 +395,14 @@ passed to ``sycl::free`` to avoid a memory leak.
 .. rubric:: Parameters
 
 ==================  ===
-``alignment``       alignment of allocated data
-``numBytes``        allocation size in bytes
-``count``           number of elements
-``syclDevice``      See :ref:`device`
-``syclQueue``       See :ref:`queue`
-``syclContext``     See :ref:`context`
-``kind``            See `usm-alloc`
-``propList``
+``alignment``       Alignment of allocated data.
+``numBytes``        Allocation size in bytes.
+``count``           Number of elements.
+``syclDevice``      See :ref:`device`.
+``syclQueue``       See :ref:`queue`.
+``syclContext``     See :ref:`context`.
+``kind``            Kind of USM allocation.
+``propList``        Optional property list.
 ==================  ===
 
 =============================
@@ -393,13 +415,13 @@ Memory deallocation functions
 
 ::
 
-   void sycl::free(void* ptr, const context& syclContext);
+   void sycl::free(void* ptr, const sycl::context& syclContext);
 
-   void sycl::free(void* ptr, const queue& syclQueue);
+   void sycl::free(void* ptr, const sycl::queue& syclQueue);
 
 Frees an allocation. The memory pointed to by ``ptr`` must have been
 allocated using one of the USM allocation routines. ``syclContext``
-must be the same ``context`` that was used to allocate the memory.
+must be the same ``sycl::context`` that was used to allocate the memory.
 The memory is freed without waiting for commands operating on
 it to be completed. If commands that use this memory are
 in-progress or are enqueued the behavior is undefined.

--- a/source/iface/usm_allocations.rst
+++ b/source/iface/usm_allocations.rst
@@ -168,7 +168,7 @@ The value returned is unspecified in this case, and the returned pointer
 may not be used to access storage. If this pointer is not null, it must be
 passed to ``sycl::free`` to avoid a memory leak.
 
-See :ref:`Events exapmle 1 <event-elapsed-time>` for usage.
+See :ref:`Events example 1 <event-elapsed-time>` for usage.
 
 
 ``sycl::malloc_host``

--- a/source/iface/usm_basic_concept.rst
+++ b/source/iface/usm_basic_concept.rst
@@ -164,7 +164,7 @@ device can be queried through ``sycl::aspect::usm_device_allocations``.
 
 The member functions to copy and initialize data are found in
 :ref:`sycl::queue shortcut functions <queue_shortcut>` and
-:ref:`sycl::handler explicit memory operations <hanlder_expl_mem_ops>`,
+:ref:`sycl::handler explicit memory operations <handler_expl_mem_ops>`,
 and these functions may be used on device allocations if a device
 supports ``sycl::aspect::usm_device_allocations``.
 
@@ -229,12 +229,12 @@ shared allocations can be queried through the aspect
    allocations, then ``prefetch`` operations may be overlapped with
    kernel execution. More about ``prefetch`` is found in
    :ref:`sycl::queue shortcut functions <queue_shortcut>` and
-   :ref:`sycl::handler explicit memory operations <hanlder_expl_mem_ops>`,
+   :ref:`sycl::handler explicit memory operations <handler_expl_mem_ops>`,
 2. Users also may use the ``mem_advise`` member function to
    annotate shared allocations with ``advice``. Valid ``advice`` is defined
    by the device and its associated backend.
    See :ref:`sycl::queue shortcut functions <queue_shortcut>`
-   and :ref:`sycl::handler explicit memory operations <hanlder_expl_mem_ops>`,
+   and :ref:`sycl::handler explicit memory operations <handler_expl_mem_ops>`,
    for more information.
 
 .. rubric:: Example

--- a/source/iface/usm_basic_concept.rst
+++ b/source/iface/usm_basic_concept.rst
@@ -162,10 +162,9 @@ memory in a device.
 Support for device allocations on a specific
 device can be queried through ``sycl::aspect::usm_device_allocations``.
 
-.. Future update: after updating "Expressing parallelism" add ref to Table 132
-
 The member functions to copy and initialize data are found in
-:ref:`sycl::queue shortcut functions <queue_shortcut>` and `Table 132`,
+:ref:`sycl::queue shortcut functions <queue_shortcut>` and
+:ref:`sycl::handler explicit memory operations <hanlder_expl_mem_ops>`,
 and these functions may be used on device allocations if a device
 supports ``sycl::aspect::usm_device_allocations``.
 
@@ -229,14 +228,14 @@ shared allocations can be queried through the aspect
    the device. If a device supports concurrent access to shared
    allocations, then ``prefetch`` operations may be overlapped with
    kernel execution. More about ``prefetch`` is found in
-   :ref:`sycl::queue shortcut functions <queue_shortcut>` and `Table 132`
+   :ref:`sycl::queue shortcut functions <queue_shortcut>` and
+   :ref:`sycl::handler explicit memory operations <hanlder_expl_mem_ops>`,
 2. Users also may use the ``mem_advise`` member function to
    annotate shared allocations with ``advice``. Valid ``advice`` is defined
    by the device and its associated backend.
    See :ref:`sycl::queue shortcut functions <queue_shortcut>`
-   and `Table 132` for more information.
-
-.. Future update: after updating "Expressing parallelism" add ref to Table 132
+   and :ref:`sycl::handler explicit memory operations <hanlder_expl_mem_ops>`,
+   for more information.
 
 .. rubric:: Example
 

--- a/source/iface/usm_pointer_queries.rst
+++ b/source/iface/usm_pointer_queries.rst
@@ -26,8 +26,8 @@ type of a USM allocation and, if applicable, the
 Pointer query functions
 =======================
 
-``get_pointer_type``
-====================
+``sycl::get_pointer_type``
+==========================
 
 ::
 
@@ -40,8 +40,8 @@ Returns ``sycl::usm::alloc::unknown`` if ``ptr`` does
 not point within a valid USM allocation from ``syclContext``.
 
 
-``get_pointer_device``
-======================
+``sycl::get_pointer_device``
+============================
 
 ::
 
@@ -58,6 +58,6 @@ context ``syclContext``, returns the first device in ``syclContext``.
 
 .. rubric:: Exceptions
 
-``errc::invalid``
+``sycl::errc::invalid``
   If ``ptr`` does not point within a valid
   USM allocation from ``syclContext``.


### PR DESCRIPTION
Issue: KHRGA-139

Updated files:
- usm_allocations.rst
- usm_basic_concept.rst 
- usm_pointer_queries.rst

Added missed ``sycl::`` prefixes and fixed referencing.