### PR TITLE
Add anatomy example to index page

### DIFF
--- a/source/anatomy.cpp
+++ b/source/anatomy.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
+
+int main() {
+  int data[1024]; // Allocate data to be worked on
+
+  // Create a default queue to enqueue work to the default device
+  queue myQueue;
+
+  // By wrapping all the SYCL work in a {} block, we ensure
+  // all SYCL tasks must complete before exiting the block,
+  // because the destructor of resultBuf will wait
+  {
+    // Wrap our data variable in a buffer
+    buffer<int, 1> resultBuf { data, range<1> { 1024 } };
+
+    // Create a command group to issue commands to the queue
+    myQueue.submit([&](handler& cgh) {
+      // Request write access to the buffer without initialization
+      accessor writeResult { resultBuf, cgh, write_only, no_init };
+
+      // Enqueue a parallel_for task with 1024 work-items
+      cgh.parallel_for(1024, [=](id<1> idx) {
+        // Initialize each buffer element with its own rank number starting at 0
+        writeResult[idx] = idx;
+      }); // End of the kernel function
+    });   // End of our commands for this queue
+  }       // End of scope, so we wait for work producing resultBuf to complete
+
+  // Print result
+  for (int i = 0; i < 1024; i++)
+    std::cout << "data[" << i << "] = " << data[i] << std::endl;
+
+  return 0;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -86,6 +86,9 @@ def make_ref(ref_str, ref_view, ref_sufix):
 
 prolog_template = string.Template(
     make_ref(
+        "SYCL_SPEC_ANATOMY", "Section 3.2", "#sec:anatomy"
+    )
+    + make_ref(
         "SYCL_SPEC_HEADER_FILES", "Section 4.3", "#sec:headers-and-namespaces"
     )
     + make_ref(

--- a/source/index.rst
+++ b/source/index.rst
@@ -23,6 +23,14 @@ you see something wrong, something that could be better, or want to
 contribute examples or descriptions, feel free to use the buttons at
 the top right to file an issue on GitHub or suggest an edit.
 
+A basic SYCL program, taken from the SYCL 2020 specification, looks like this:
+
+[source,,linenums]
+----
+include::anatomy.cpp[lines=4..-1]
+----
+.. seealso:: |SYCL_SPEC_ANATOMY|
+
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
People new to SYCL might want to see a simple SYCL program so that they can then investigate the APIs further in the rest of this reference page, so I've included the anatomy example from the SYCL 2020 spec on the main page