### PR TITLE
Clarifications to header file and namespace sections

### DIFF
--- a/source/header-file.rst
+++ b/source/header-file.rst
@@ -2,17 +2,30 @@
   Copyright 2024 The Khronos Group Inc.
   SPDX-License-Identifier: CC-BY-4.0
 
-=============
- Header File
-=============
+==============
+ Header Files
+==============
 
-SYCL provides one standard header file:
+SYCL provides a single standard header file:
 
 ::
 
    #include <sycl/sycl.hpp>
 
-which needs to be included in every translation unit that uses the
-SYCL programming API.
+which needs to be included in every translation unit that uses the SYCL
+programming API.
+
+For compatibility with the earlier version; SYCL 1.2.1, SYCL also provides
+another header file:
+
+::
+
+   #include <CL/sycl.hpp>
+
+which can be used in place of ``sycl/sycl.hpp``, providing all of the same SYCL
+programming API, though it is recommended to use ``sycl/sycl.hpp``.
+
+Extension headers are available in ``sycl/ext/`` include paths and backend-
+specific headers are available in ``sycl/backend/`` include paths.
 
 .. seealso:: |SYCL_SPEC_HEADER_FILES|

--- a/source/namespaces.rst
+++ b/source/namespaces.rst
@@ -6,9 +6,9 @@
 Namespaces
 ==========
 
-All SYCL classes, constants, types and functions are available in the ``sycl::``
-namespace, unless the ``CL/sycl.hpp`` header is used in which case they are all
-available in the ``cl::sycl::`` namespace.
+All SYCL classes, constants, types and functions are available in the
+``sycl::`` namespace, unless the ``CL/sycl.hpp`` header is used in which case
+they are all available in the ``cl::sycl::`` namespace.
 
 All SYCL backend-specific functionality is made available in the
 namespace ``sycl::<backend_name>`` where ``<backend_name>`` is the

--- a/source/namespaces.rst
+++ b/source/namespaces.rst
@@ -6,8 +6,9 @@
 Namespaces
 ==========
 
-Unless otherwise noted, all SYCL classes, constants, types and
-functions should be prefixed with the ``sycl::`` namespace.
+All SYCL classes, constants, types and functions are available in the ``sycl::``
+namespace, unless the ``CL/sycl.hpp`` header is used in which case they are all
+available in the ``cl::sycl::`` namespace.
 
 All SYCL backend-specific functionality is made available in the
 namespace ``sycl::<backend_name>`` where ``<backend_name>`` is the


### PR DESCRIPTION
* Add mention of the `CL/sycl.hpp` header and `cl::sycl` namespace for compatibility with SYCL 1.2.1.
* Add Mention sycl/ext/ and sycl/backend/ include paths under include files section.